### PR TITLE
Fix problem on windows

### DIFF
--- a/ctrtool/romfs.h
+++ b/ctrtool/romfs.h
@@ -82,7 +82,7 @@ int  romfs_dirblock_readentry(romfs_context* ctx, u32 diroffset, romfs_direntry*
 int  romfs_fileblock_read(romfs_context* ctx, u32 fileoffset, u32 filesize, void* buffer);
 int  romfs_fileblock_readentry(romfs_context* ctx, u32 fileoffset, romfs_fileentry* entry);
 void romfs_visit_dir(romfs_context* ctx, u32 diroffset, u32 depth, u32 actions, filepath* rootpath);
-void romfs_visit_file(romfs_context* ctx, u32 fileoffset, u32 depth, u32 actions, filepath* rootpath);
+u32 romfs_visit_file(romfs_context *ctx, u32 fileoffset, u32 depth, u32 actions, filepath *rootpath);
 void romfs_extract_datafile(romfs_context* ctx, u64 offset, u64 size, filepath* path);
 void romfs_process(romfs_context* ctx, u32 actions);
 void romfs_print(romfs_context* ctx);

--- a/ctrtool/utils.h
+++ b/ctrtool/utils.h
@@ -10,7 +10,7 @@
 #endif
 
 #ifndef MAX_PATH
-	#define MAX_PATH 255
+	#define MAX_PATH 260
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
MAX_PATH is defined in stdlib as 260 on windows.
As some source files included stdlib and some not, it made the program crash because of different sizes of the filepath structure.
You can check it with sizeof(filepath) in romfs.c and settings.h.
Tested on MinGW latest update.
